### PR TITLE
Append user approval files to backup directory.

### DIFF
--- a/create.py
+++ b/create.py
@@ -131,25 +131,17 @@ def main(args):
         check_call(["kdestroy"])
 
     if options.backup:
-        dest = os.path.join(options.backup, str(datetime.now()))
+        files = [options.mid_approve, options.users_file]
 
-        try:
-            os.makedirs(dest)
-        except OSError as e:
-            if e.errno != errno.EEXIST:
-                raise e
+        for s_path in files:
+            if os.path.isfile(s_path):
+                d_path = os.path.join(options.backup, os.path.basename(s_path))
 
-        try:
-            shutil.copy(options.mid_approve, dest)
-        except IOError as e:
-            if e.errno != errno.ENOENT:
-                raise e
+                with open(d_path, "a") as dest, open(s_path) as src:
+                    now = datetime.now()
+                    dest.write("# Backup of {0} as it appeared on {1}\n".format(s_path, now))
 
-        try:
-            shutil.copy(options.users_file, dest)
-        except IOError as e:
-            if e.errno != errno.ENOENT:
-                raise e
+                    shutil.copyfileobj(src, dest)
 
     # Process all of the recently requested accounts
     with fancy_open(options.users_file, lock = True,


### PR DESCRIPTION
Please take a look at let me know if this looks reasonable. Since it doesn't really matter the current state of the files (e.g. concatenating/appending files is ok), this makes it a lot easier to use logrotate to get rid of old backups after a certain time period.

I tested this with the account processing disabled and it works as intended, but it should be tested by somebody who can actually process accounts as well.

Instead of creating new directories in the backup directory which hold
the approved.users and mid_approved.users files as they were at the time
the script was run, just append the files to "approved.users" and
"mid_approved.users" in the backup directory.

This keeps all backups in two files which can easily be integrated with
logrotate in order to automatically delete old files when they're no
longer needed. This is desirable because these files contain encrypted
user passwords, which only need to be stored until the request is
processed, at which time the password is hashed and the encrypted copy
should be securely discarded.

The files are simply appended, which means that it's possible that
duplicate entries will appear in the backup files if, for example, an
account is not processed. This is not really a concern since the backup
files are only for human use.
